### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+Thank you for making a pull request to ZTM's Animation Nation project. We will review your pull request as soon as we can, but keep in mind we can get very busy during Hacktoberfest.
+
+While you're waiting, please look over this checklist. Feel free to write a description of what you did as well!
+
+## What I did
+
+*Optional: Edit this to tell us what you did!*
+
+## Pull request checklist
+
+- [ ] This pull request uses **HTML and CSS** only.
+- [ ] All files in this pull request are in a directory named: `<github_username>-<art_name>` without the <>.
+- [ ] Your pull request contains only `index.html` and `styles.css`.
+- [ ] Your html file is named exactly: `index.html`
+- [ ] Your css file is named exactly: `styles.css`
+- [ ] Your submission includes **at least one animation**.
+- [ ] Your pull request **does not modify any other files** in the repository.
+
+#### Not normally needed
+- [ ] Check this if you would like to discuss an improvement besides adding animations
+
+**Note: if your pull request makes an improvement besides adding a CSS animation you will need to discuss this with the maintainers. You can help kickstart this process by explaining what your change does and why you are making it in the "What I did" section**
+
+## What to expect
+
+- If your pull request meets the checklist requirements it will be approved and merged by a maintainer
+- If your pull request needs some changes. A maintainer will leave a comment requesting changes
+- If your pull request significantly violates the criteria in the checklist it will be closed with feedback.


### PR DESCRIPTION
# What this does
I think it would be helpful both for contributors and maintainers to have a pull request template that explains:

- What to expect
- What acceptance criteria we are looking for

Adding `pull_request_template.md` to the `.github` directory will cause the template to show up by default on all new PRs (see [docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) if unfamiliar).

I am happy to make changes to the wording, or to close this and let someone officially affiliated with ZTM write the template.

But I thought I would submit this PR as a means to get a discussion started.