### PR TITLE
fix: fix crash in format action

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -3,11 +3,11 @@ on: push
 
 jobs:
   format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Pull Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -27,17 +27,13 @@ jobs:
             exit 1;
           fi
 
-          prettier --check . --ignore-unknown --write
+          prettier . --ignore-unknown --write
 
       # Configure Git
       - name: Configure Git
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-
-      # Check for changes
-      - name: Check for changes
-        run: git pull
 
       # Add, commit, and push changes
       - name: Commit and push cards.json

--- a/.github/workflows/generate-cards.yml
+++ b/.github/workflows/generate-cards.yml
@@ -10,26 +10,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    # Run the script to generate cards.json
-    - name: Generate cards.json
-      run: node generators/generateCards.js
+      # Run the script to generate cards.json
+      - name: Generate cards.json
+        run: node generators/generateCards.js
 
-    # Configure Git
-    - name: Configure Git
-      run: |
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
+      # Configure Git
+      - name: Configure Git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
 
-    # Check if there are changes in public/cards.json
-    - name: Check for changes
-      run: |
-        if git diff --quiet public/cards.json; then
-          echo "No changes to commit"
-        else
-          git add public/cards.json
-          git commit -m "(CI) cards.json Generation"
-          git push
-        fi
+      # Check if there are changes in public/cards.json
+      - name: Check for changes
+        run: |
+          if git diff --quiet public/cards.json; then
+            echo "No changes to commit"
+          else
+            git add public/cards.json
+            git commit -m "(CI) cards.json Generation"
+            git push
+          fi

--- a/.github/workflows/generate-cards.yml
+++ b/.github/workflows/generate-cards.yml
@@ -1,12 +1,15 @@
 name: Generate Includes
 
 on:
-  push:
+  pull_request:
     branches:
       - master
+    types:
+      - closed
 
 jobs:
   generateIncludes:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -1,12 +1,15 @@
 name: Generate Screenshots
 
 on:
-  push:
+  pull_request:
     branches:
       - master
+    types:
+      - closed
 
 jobs:
   screenshots:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -10,37 +10,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # Fetch full history to ensure all commits are accessible
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch full history to ensure all commits are accessible
 
-    # Install Puppeteer
-    - name: Install Puppeteer
-      run: npm install puppeteer
+      # Install Puppeteer
+      - name: Install Puppeteer
+        run: npm install puppeteer
 
-    # Install Sharp
-    - name: Install Sharp
-      run: npm install sharp
+      # Install Sharp
+      - name: Install Sharp
+        run: npm install sharp
 
-    # Run Puppeteer script to generate screenshots
-    - name: Generate screenshots
-      run: node generators/generateScreenshot.js
+      # Run Puppeteer script to generate screenshots
+      - name: Generate screenshots
+        run: node generators/generateScreenshot.js
 
-    - name: Commit and Push Screenshots
-      run: |
-        # Configure git
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
+      - name: Commit and Push Screenshots
+        run: |
+          # Configure git
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
 
-        # Check for changes
-        git pull
-        
-        # Add changes
-        git add Art/**/icon.png
-        
-        # Commit changes if there are any
-        git commit -m "(CI) Screenshot Generation" || echo "No changes to commit"
-        
-        # Push changes
-        git push
+          # Check for changes
+          git pull
+
+          # Add changes
+          git add Art/**/icon.png
+
+          # Commit changes if there are any
+          git commit -m "(CI) Screenshot Generation" || echo "No changes to commit"
+
+          # Push changes
+          git push


### PR DESCRIPTION
## What I did

The format action is crashing on certain runs (e.g. see [here](https://github.com/zero-to-mastery/Animation-Nation/actions/runs/11155644698/job/31006900038)) when running prettier makes changes. Looking at the logs, this is because `git pull` fails when there are changed files that are not spoken for.

I'm not sure it makes sense to do a `git pull` step at all here because `actions/checkout` should already have pulled the changes.

This pr:
- removes git pull step in format job which should fix the crashes
- updates the deprecated `actions/checkout@v2` to v4. I believe breaking changes shouldn't be a concern in this case.
- removes `--check` from prettier invocation as it's redundant with `--write`

If there was some reason for the git pull step I am overlooking we may need to address the crashing differently.

## Pull request checklist

- [ ] This pull request uses **HTML and CSS** only.
- [ ] All files in this pull request are in a directory named: `<github_username>-<art_name>` without the <>.
- [ ] Your pull request contains only `index.html` and `styles.css`.
- [ ] Your html file is named exactly: `index.html`
- [ ] Your css file is named exactly: `styles.css`
- [ ] Your submission includes **at least one animation**.
- [ ] Your pull request **does not modify any other files** in the repository.

#### Not normally needed
- [x] Check this if you would like to discuss an improvement besides adding animations

**Note: if your pull request makes an improvement besides adding a CSS animation you will need to discuss this with the maintainers. You can help kickstart this process by explaining what your change does and why you are making it in the "What I did" section**