### PR TITLE
fix: add permissions for screenshot jobs

### DIFF
--- a/.github/workflows/generate-cards.yml
+++ b/.github/workflows/generate-cards.yml
@@ -6,12 +6,15 @@ on:
       - master
     types:
       - closed
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   generateIncludes:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -7,11 +7,15 @@ on:
     types:
       - closed
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   screenshots:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## What I did

Two actions are failing for what looks like permissions related reasons. This adds the github token to the environment and gives write permissions for repo contents. I think this will fix the issue we're seeing.

#### Not normally needed
- [x] Check this if you would like to discuss an improvement besides adding animations