### PR TITLE
[ fix/maintainance__hyphens-edge-cases ]

### DIFF
--- a/generators/generateCards.js
+++ b/generators/generateCards.js
@@ -1,43 +1,61 @@
 const fs = require("fs");
 const path = require("path");
+const { handleExtraHyphens} = require('./generateCards.services');
+
 
 const artDir = "./Art";
 
 // Function to generate the includes.js content
-function generateIncludes() {
+async function generateIncludes() {
   const studentDirs = fs
     .readdirSync(artDir)
     .filter((dir) => fs.lstatSync(path.join(artDir, dir)).isDirectory());
 
   const cards = [];
 
-  studentDirs.forEach((dir) => {
-    const projectPath = path.join(artDir, dir);
+	for(const dir of studentDirs){
+      const projectPath = path.join(artDir, dir);
+	  const dirDetailsStrings = dir.split('-');
+	  
+	  
+	  // handle name
+	  let authorName = dirDetailsStrings[0]; // Default authorName case - first word before first hyphen
+	  let projectName = dirDetailsStrings.slice(1).join('-'); // Default authorName case - Everything after the first hyphen
+	  
+	  /**
+	   * Two cases to consider
+	   * - username can have hyphen(s)
+	   * - title can have hyphen(s)
+	   * Overrides once more than one hyphens is detected by
+	   * checking existence of github user's URL
+	   */
+	  const BASIC_LENGTH_CASE = 2;
+	  const shouldHandleExtraHyphens = dirDetailsStrings.length > BASIC_LENGTH_CASE;
+	  if(shouldHandleExtraHyphens){
+	  	const data = await handleExtraHyphens(dirDetailsStrings);
+	  	authorName 	= data.authorName;
+	  	projectName = data.projectName;
+	  }
+  
+      projectName = projectName.replace(/([A-Z])/g, ' $1').trim(); // Handles camel case project name
 
-    // Use directory name, splitting on the last hyphen
-    const lastHyphenIndex = dir.lastIndexOf('-');
-    const authorName = dir.substring(0, lastHyphenIndex); // Everything before the last hyphen
-    let projectName = dir.substring(lastHyphenIndex + 1); // Everything after the last hyphen
-    projectName = projectName.replace(/([A-Z])/g, ' $1').trim(); // Handles camel case project name
-
-    // Handles underscores case in project name
-    if( projectName.includes('_') ){
-      projectName = projectName.replace(/(_)/g, ' ').trim();
-    }
-
-    const projectUrl = `./Art/${dir}/index.html`;
-    const projectImage = `./Art/${dir}/icon.png`;
-
-    // Add the project to the cards array
-    cards.push({
-      artName: projectName,
-      pageLink: projectUrl,
-      imageLink: projectImage,
-      author: authorName,
-      githubLink: `https://github.com/${authorName}`,
-      projectPath
-    });
-  });
+       // Handles underscores case in project name
+      if( projectName.includes('_') ){
+        projectName = projectName.replace(/(_)/g, ' ').trim();
+      }
+      const projectUrl = `./Art/${dir}/index.html`;
+      const projectImage = `./Art/${dir}/icon.png`;
+  
+      // Add the project to the cards array
+      cards.push({
+        artName: projectName,
+        pageLink: projectUrl,
+        imageLink: projectImage,
+        author: authorName,
+        githubLink: `https://github.com/${authorName}`,
+        projectPath
+      });
+	}
 
 
   // Write the content to includes.js file
@@ -45,3 +63,4 @@ function generateIncludes() {
 }
 
 generateIncludes();
+

--- a/generators/generateCards.services.js
+++ b/generators/generateCards.services.js
@@ -1,0 +1,53 @@
+const util = require("node:util");
+const { exec } = require('node:child_process');
+const execPromise = util.promisify(exec);
+
+
+/**
+ * Checks URL requests response status code
+ * - is 404: username does not exist
+ * - else: username does exist
+ */
+async function isExistingGithubUsername ( possibleUsername ){
+	const githubUrl = `https://github.com/${possibleUsername}`;
+	const curlRequestForStatusCode = `curl --head -s "${githubUrl}" | awk 'NR==1 {print $2}'`;
+
+	try {
+		const { stdout } = await execPromise(curlRequestForStatusCode);
+		return Number(stdout) !== 404;
+	} catch( error ){
+		return false;
+	}
+}
+
+/**
+ * Handles directory names with multiple hyphens to get 
+ * the real distinction between the official author name and
+ * the project name
+ * @returns authorName, projectName 
+ */
+async function handleExtraHyphens(detailsStrings){
+	let endUsernameIdx = detailsStrings.length - 1;
+	let dataDetails;
+
+	// while it is within author name possible range
+	while (endUsernameIdx >= -1 && !dataDetails ){
+		let potentialUsername = detailsStrings
+			.slice(0, endUsernameIdx)
+			.join('-');
+		const isExistingUserName = await isExistingGithubUsername(potentialUsername);
+
+		if ( isExistingUserName ){
+			dataDetails = {
+				authorName: potentialUsername,
+				projectName: detailsStrings.slice(endUsernameIdx).join('-')
+			}
+		}
+		endUsernameIdx -= 1;
+	}
+	return dataDetails;
+}
+
+module.exports = {
+	handleExtraHyphens
+}


### PR DESCRIPTION
- if more than one hyphen in dir. name: will get the real
  - authorName *(based on found github url using curl)*
  - projectName: being the remaining string
  
Current implementation check the username in reverse direction:
Usually an existing username is appending a value to be unique
Ex: SJ ( author in card / link in card ) is not the same person as SJ-209
- https://github.com/SJ : is not the one that contributed
- https://github.com/SJ-209 : is the one that contributed - which we can retrieve in 
the fix implementation ( pict 1 ) 
  
### The Fix detecting folders name with multiple hyphens
<img width="561" alt="image" src="https://github.com/user-attachments/assets/e6cb8f1d-e166-43fb-994e-55057c11fba8">


### Former generated cards authorName and projectName deduction
<img width="469" alt="image" src="https://github.com/user-attachments/assets/08ac95ba-c552-4b58-bf40-8c6498f993cb">

<img width="571" alt="image" src="https://github.com/user-attachments/assets/ac5577bd-1aeb-4f17-b5d4-acb66a903355">
<img width="576" alt="image" src="https://github.com/user-attachments/assets/01bc60fb-dd84-4893-addb-912cbb0438c5">
