### PR TITLE
Revert "test: temporarily remove diff checks"

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -50,6 +50,7 @@ jobs:
             git commit -m "(CI) cards.json Generation"
           fi
       - name: Format cards
+        if: env.SKIP_REST != 'true'
         run: |
           if [ ! -f .prettierrc ]; then
             echo ".prettierrc not found"
@@ -60,9 +61,11 @@ jobs:
           git add public/cards.json
           git commit -m "(CI) Format cards" || echo "No changes to commit"
       - name: Generate screenshots
+        if: env.SKIP_REST != 'true'
         run: |
           node generators/generateScreenshot.js
           git add Art/**/icon.png
           git commit -m "(CI) Screenshot Generation" || echo "No changes to commit"
       - name: Push changes
+        if: env.SKIP_REST != 'true'
         run: git push origin master


### PR DESCRIPTION
Reverts zero-to-mastery/Animation-Nation#2679

This branch only existed to force action to run all the way through. I think we generally DO want to run diff checks (unless there's issues with git diff here. But that's another story)