### PR TITLE
fix glob pattern in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /node_modules
-**/*/.DS_Store
+**/.DS_Store


### PR DESCRIPTION
## What I did

The ignore pattern for .DS_Store does not ignore them at the root level of the repo where they are likely most common. This updates the glob pattern to ignore .DS_Store anywhere in the repo.

## Pull request checklist

- [x] Check this if you would like to discuss an improvement besides adding animations

**Note: if your pull request makes an improvement besides adding a CSS animation you will need to discuss this with the maintainers. You can help kickstart this process by explaining what your change does and why you are making it in the "What I did" section**