### PR TITLE
[ fix/meta-contributors ] Fixes project author / project name / githu…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,11 +8,14 @@ While you're waiting, please look over this checklist. Feel free to write a desc
 
 ## Pull request checklist
 
-- [ ] This pull request uses **HTML and CSS** only.
+- [ ] This pull request uses **HTML and CSS** only and provides a `meta.json` file.
 - [ ] All files in this pull request are in a directory named: `<github_username>-<art_name>` without the <>.
-- [ ] Your pull request contains only `index.html` and `styles.css`.
-- [ ] Your html file is named exactly: `index.html`
-- [ ] Your css file is named exactly: `styles.css`
+- [ ] Your pull request contains `index.html` and `styles.css`.
+	- [ ] Your html file is named exactly: `index.html`
+	- [ ] Your css file is named exactly: `styles.css`
+- [ ] Your pull request your `meta.json` with:
+	- [ ] `githubHandle`: being your unique github user name,
+	- [ ] `artName` : name of your animation
 - [ ] Your submission includes **at least one animation**.
 - [ ] Your pull request **does not modify any other files** in the repository.
 

--- a/Art/AAbhijithA-waveAnimation/meta.json
+++ b/Art/AAbhijithA-waveAnimation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "AAbhijithA",
+  "artName": "wave Animation"
+}

--- a/Art/AlexanderSanin-spinning-loader/meta.json
+++ b/Art/AlexanderSanin-spinning-loader/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "AlexanderSanin",
+  "artName": "spinning loader"
+}

--- a/Art/Argwingskodhek-rotatingBall/meta.json
+++ b/Art/Argwingskodhek-rotatingBall/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Argwingskodhek",
+  "artName": "rotating Ball"
+}

--- a/Art/Astro-Dude-animatedButton/meta.json
+++ b/Art/Astro-Dude-animatedButton/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Astro-Dude",
+  "artName": "animated Button"
+}

--- a/Art/BaraniVA-Typewriter/meta.json
+++ b/Art/BaraniVA-Typewriter/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "BaraniVA",
+  "artName": "Typewriter"
+}

--- a/Art/BrianCheung1-Balloons/meta.json
+++ b/Art/BrianCheung1-Balloons/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "BrianCheung1",
+  "artName": "Balloons"
+}

--- a/Art/Debajyati-Omnitrix/meta.json
+++ b/Art/Debajyati-Omnitrix/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Debajyati",
+  "artName": "Omnitrix"
+}

--- a/Art/Debajyati-sunmoon/meta.json
+++ b/Art/Debajyati-sunmoon/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Debajyati",
+  "artName": "sunmoon"
+}

--- a/Art/HASH-0021-Telephone/meta.json
+++ b/Art/HASH-0021-Telephone/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "HASH-0021",
+  "artName": "Telephone"
+}

--- a/Art/JayShukla8-cat/meta.json
+++ b/Art/JayShukla8-cat/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "JayShukla8",
+  "artName": "cat"
+}

--- a/Art/Kaif-Azmi-Celestial-Dance/meta.json
+++ b/Art/Kaif-Azmi-Celestial-Dance/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Kaif-Azmi",
+  "artName": "Celestial Dance"
+}

--- a/Art/Kaif-Azmi-Hacktoberfest-Animation/meta.json
+++ b/Art/Kaif-Azmi-Hacktoberfest-Animation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Kaif-Azmi",
+  "artName": "Hacktoberfest Animation"
+}

--- a/Art/Kisalaykisu-cubeAnimation/meta.json
+++ b/Art/Kisalaykisu-cubeAnimation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Kisalaykisu",
+  "artName": "cube Animation"
+}

--- a/Art/Kisalaykisu-particleRingAnimation/meta.json
+++ b/Art/Kisalaykisu-particleRingAnimation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Kisalaykisu",
+  "artName": "particle Ring Animation"
+}

--- a/Art/Kisalaykisu-ztmLogoAnimation/meta.json
+++ b/Art/Kisalaykisu-ztmLogoAnimation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Kisalaykisu",
+  "artName": "ztm Logo Animation"
+}

--- a/Art/Nishankulal03-loader/meta.json
+++ b/Art/Nishankulal03-loader/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Nishankulal03",
+  "artName": "loader"
+}

--- a/Art/Pauljd1-Pumpkin/meta.json
+++ b/Art/Pauljd1-Pumpkin/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Pauljd1",
+  "artName": "Pumpkin"
+}

--- a/Art/SJ-209-loader/meta.json
+++ b/Art/SJ-209-loader/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "SJ-209",
+  "artName": "loader"
+}

--- a/Art/SagarVerma893-Flickering Neon Sign/meta.json
+++ b/Art/SagarVerma893-Flickering Neon Sign/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "SagarVerma893",
+  "artName": "Flickering Neon Sign"
+}

--- a/Art/SagarVerma893-orbitalMotion/meta.json
+++ b/Art/SagarVerma893-orbitalMotion/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "SagarVerma893",
+  "artName": "orbital Motion"
+}

--- a/Art/SammyUrfen-pendulum/meta.json
+++ b/Art/SammyUrfen-pendulum/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "SammyUrfen",
+  "artName": "pendulum"
+}

--- a/Art/SumitDutta007-bubbles/meta.json
+++ b/Art/SumitDutta007-bubbles/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "SumitDutta007",
+  "artName": "bubbles"
+}

--- a/Art/SumitDutta007-scroll/meta.json
+++ b/Art/SumitDutta007-scroll/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "SumitDutta007",
+  "artName": "scroll"
+}

--- a/Art/THE-ASHUTOSH-button-animation/meta.json
+++ b/Art/THE-ASHUTOSH-button-animation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "THE-ASHUTOSH",
+  "artName": "button animation"
+}

--- a/Art/Tushar-0202-Shaw-FrontPage/meta.json
+++ b/Art/Tushar-0202-Shaw-FrontPage/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Tushar-0202-Shaw",
+  "artName": "Front Page"
+}

--- a/Art/Yadnyesh-Dashpute-AnimatedForm/meta.json
+++ b/Art/Yadnyesh-Dashpute-AnimatedForm/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "Yadnyesh-Dashpute",
+  "artName": "Animated Form"
+}

--- a/Art/aayu5hgit-LoaderAnimation/meta.json
+++ b/Art/aayu5hgit-LoaderAnimation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "aayu5hgit",
+  "artName": "Loader Animation"
+}

--- a/Art/alienx5499-profilecard/meta.json
+++ b/Art/alienx5499-profilecard/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "alienx5499",
+  "artName": "profilecard"
+}

--- a/Art/bandhan-majumder-loadingDino/meta.json
+++ b/Art/bandhan-majumder-loadingDino/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "bandhan-majumder",
+  "artName": "loading Dino"
+}

--- a/Art/charlomatic-CircleSlider/meta.json
+++ b/Art/charlomatic-CircleSlider/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "charlomatic",
+  "artName": "Circle Slider"
+}

--- a/Art/dev1abhi-Hindu-Swastika/meta.json
+++ b/Art/dev1abhi-Hindu-Swastika/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "dev1abhi",
+  "artName": "Hindu Swastika"
+}

--- a/Art/fullspeccoder-scaryface/meta.json
+++ b/Art/fullspeccoder-scaryface/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "fullspeccoder",
+  "artName": "scaryface"
+}

--- a/Art/hanisntsolo-verticalballsbounce/meta.json
+++ b/Art/hanisntsolo-verticalballsbounce/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "hanisntsolo",
+  "artName": "verticalballsbounce"
+}

--- a/Art/harshporwal03-heart_beat_animation/meta.json
+++ b/Art/harshporwal03-heart_beat_animation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "harshporwal03",
+  "artName": "heart beat_animation"
+}

--- a/Art/hoangnv170752-loading/meta.json
+++ b/Art/hoangnv170752-loading/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "hoangnv170752",
+  "artName": "loading"
+}

--- a/Art/hoangnv170752-pinball/meta.json
+++ b/Art/hoangnv170752-pinball/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "hoangnv170752",
+  "artName": "pinball"
+}

--- a/Art/jayg2309-ColorfulWaves/meta.json
+++ b/Art/jayg2309-ColorfulWaves/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "jayg2309",
+  "artName": "Colorful Waves"
+}

--- a/Art/jeevaramanathan-bouncingball/meta.json
+++ b/Art/jeevaramanathan-bouncingball/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "jeevaramanathan",
+  "artName": "bouncingball"
+}

--- a/Art/kasunJayasanka-pixelLoading/meta.json
+++ b/Art/kasunJayasanka-pixelLoading/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "kasunJayasanka",
+  "artName": "pixel Loading"
+}

--- a/Art/kishan-25-3D/meta.json
+++ b/Art/kishan-25-3D/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "kishan-25",
+  "artName": "3D"
+}

--- a/Art/kishan-25-Animated-Timeline/meta.json
+++ b/Art/kishan-25-Animated-Timeline/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "kishan-25",
+  "artName": "Animated Timeline"
+}

--- a/Art/kishan-25-Dino-Loading-Animation/meta.json
+++ b/Art/kishan-25-Dino-Loading-Animation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "kishan-25",
+  "artName": "Dino Loading Animation"
+}

--- a/Art/kishan-25-animated-backgroundcolor-changer/meta.json
+++ b/Art/kishan-25-animated-backgroundcolor-changer/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "kishan-25",
+  "artName": "animated backgroundcolor changer"
+}

--- a/Art/laurelinep-drippingCoffee/meta.json
+++ b/Art/laurelinep-drippingCoffee/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "laurelinep",
+  "artName": "dripping Coffee"
+}

--- a/Art/mattcsmith-triangle/meta.json
+++ b/Art/mattcsmith-triangle/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "mattcsmith",
+  "artName": "triangle"
+}

--- a/Art/nabinkumarshaw-Animation/meta.json
+++ b/Art/nabinkumarshaw-Animation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "nabinkumarshaw",
+  "artName": "Animation"
+}

--- a/Art/nabinkumarshaw-Bouncing_ball_animation/meta.json
+++ b/Art/nabinkumarshaw-Bouncing_ball_animation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "nabinkumarshaw",
+  "artName": "Bouncing ball_animation"
+}

--- a/Art/nabinkumarshaw-animatedgeometry/meta.json
+++ b/Art/nabinkumarshaw-animatedgeometry/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "nabinkumarshaw",
+  "artName": "animatedgeometry"
+}

--- a/Art/nabinkumarshaw-rotating_cube/meta.json
+++ b/Art/nabinkumarshaw-rotating_cube/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "nabinkumarshaw",
+  "artName": "rotating cube"
+}

--- a/Art/pleomorph-happyhacktoberfest/meta.json
+++ b/Art/pleomorph-happyhacktoberfest/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "pleomorph",
+  "artName": "happyhacktoberfest"
+}

--- a/Art/rutubhanderi-sunrise-animation/meta.json
+++ b/Art/rutubhanderi-sunrise-animation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "rutubhanderi",
+  "artName": "sunrise animation"
+}

--- a/Art/samilabud-piramidSunSet/meta.json
+++ b/Art/samilabud-piramidSunSet/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "samilabud",
+  "artName": "piramid Sun Set"
+}

--- a/Art/shuaixr-twilight_voyage/meta.json
+++ b/Art/shuaixr-twilight_voyage/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "shuaixr",
+  "artName": "twilight voyage"
+}

--- a/Art/smitthakore-oreo/meta.json
+++ b/Art/smitthakore-oreo/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "smitthakore",
+  "artName": "oreo"
+}

--- a/Art/somnath0904-AnimatedPage/meta.json
+++ b/Art/somnath0904-AnimatedPage/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "somnath0904",
+  "artName": "Animated Page"
+}

--- a/Art/somnath0904-HandAnimation/meta.json
+++ b/Art/somnath0904-HandAnimation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "somnath0904",
+  "artName": "Hand Animation"
+}

--- a/Art/somnath0904-LoginPage/meta.json
+++ b/Art/somnath0904-LoginPage/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "somnath0904",
+  "artName": "Login Page"
+}

--- a/Art/somnath0904-OrbittingCircles/meta.json
+++ b/Art/somnath0904-OrbittingCircles/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "somnath0904",
+  "artName": "Orbitting Circles"
+}

--- a/Art/staticBird-helicopterAnimation/meta.json
+++ b/Art/staticBird-helicopterAnimation/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "staticBird",
+  "artName": "helicopter Animation"
+}

--- a/Art/strykeFreedom08-JumpingStickman/meta.json
+++ b/Art/strykeFreedom08-JumpingStickman/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "strykeFreedom08",
+  "artName": "Jumping Stickman"
+}

--- a/Art/stutxi-animatedEyes/meta.json
+++ b/Art/stutxi-animatedEyes/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "stutxi",
+  "artName": "animated Eyes"
+}

--- a/Art/surjayankar-DynamicRotatingSquares/meta.json
+++ b/Art/surjayankar-DynamicRotatingSquares/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "surjayankar",
+  "artName": "Dynamic Rotating Squares"
+}

--- a/Art/surjayankar-verticalballsbounceloader/meta.json
+++ b/Art/surjayankar-verticalballsbounceloader/meta.json
@@ -1,0 +1,4 @@
+{
+  "githubHandle": "surjayankar",
+  "artName": "verticalballsbounceloader"
+}

--- a/README.md
+++ b/README.md
@@ -70,8 +70,19 @@ Working in the master or main branch is often frowned upon and are usually expec
 Now for the fun part! Inside the `Art/` folder:
 
 - Create a new directory named: <github_username>-<art_name> eg. `mattcsmith-helloworld`.
-- Inside **your** folder, create an index.html file
-- Inside **your** folder, create an styles.css file
+- Inside **your** folder, create an `index.html` file
+- Inside **your** folder, create an `styles.css` file
+- Inside **your** folder, create an `meta.json` file   
+to specify your art name, github author and github link  
+Note: copy the following snippet and replace only the values with your own details,  
+Do not change the JSON keys.
+```json
+// Example
+{
+    "artName": "hello world",
+    "githubHandle": "mattcsmith"
+}
+```
 - Use these to create your **animated artwork** — let your creativity flow!
 
 ⚠️ It is important to name the directory and your files exactly as mentioned above ⚠️

--- a/generators/__fixWithMetaData.js
+++ b/generators/__fixWithMetaData.js
@@ -1,0 +1,105 @@
+/**
+	File to remove once the project repo is updated for 
+	all user to include `meta.json`
+	- accordingly: we need to remove:
+	 	- import in `./generateCards.js`
+		- its execution block in `./generateCards.js`
+		where the TODO comment is 
+ */
+
+const util 			= require("node:util");
+const { exec } 		= require('node:child_process');
+
+const fs 			= require('node:fs');
+const path 			= require('node:path');
+const { formatProjectName } = require('./utils');
+const CONTRIBUTIONS_FOLDER 	= path.resolve(__dirname, '..', 'Art');
+
+const execPromise 	= util.promisify(exec);
+
+/** Init empty meta.json file or updates it */
+const handleMetaFile = ( folderName, metaData ) => {
+	const metaFileTemplate = {
+		"artName" : "",
+		"githubHandle" : "",
+	}
+	const metaFilePath = path.resolve( CONTRIBUTIONS_FOLDER, folderName, 'meta.json' );
+	const _metaData = metaData || metaFileTemplate;
+	fs.writeFileSync(
+		metaFilePath,
+		JSON.stringify(_metaData, null, 2)
+	);
+}
+
+/** Either create an empty file or updates it */
+const handleMissingMetaData = async (folderName) => {
+	const details = folderName.split('-');
+	const shouldHandleExtraHyphens = details.length > 2;
+	let githubHandle, artName;
+
+	if( shouldHandleExtraHyphens ){
+        const data = await handleExtraHyphens(details);
+		githubHandle 	= data.authorName;
+		artName = data.projectName;
+	} else {
+		githubHandle 	= details[0];
+		artName = details[1];
+	}
+
+	const currentMetaData = {
+		githubHandle,
+		artName: formatProjectName(artName)
+	}
+	handleMetaFile( folderName, currentMetaData );
+}
+
+
+module.exports = { handleMissingMetaData };
+
+
+
+
+/**
+ * Checks URL requests response status code
+ * - is 404: username does not exist
+ * - else: username does exist
+ */
+async function isExistingGithubUsername ( possibleUsername ){
+	const githubUrl = `https://github.com/${possibleUsername}`;
+	const curlRequestForStatusCode = `curl --head -s "${githubUrl}" | awk 'NR==1 {print $2}'`;
+
+	try {
+		const { stdout } = await execPromise(curlRequestForStatusCode);
+		return Number(stdout) !== 404;
+	} catch( error ){
+		return false;
+	}
+}
+
+/**
+ * Handles directory names with multiple hyphens to get 
+ * the real distinction between the official author name and
+ * the project name
+ * @returns authorName, projectName 
+ */
+async function handleExtraHyphens(detailsStrings){
+	let endUsernameIdx = detailsStrings.length - 1;
+	let dataDetails;
+
+	// while it is within author name possible range
+	while (endUsernameIdx >= -1 && !dataDetails ){
+		let potentialUsername = detailsStrings
+			.slice(0, endUsernameIdx)
+			.join('-');
+		const isExistingUserName = await isExistingGithubUsername(potentialUsername);
+
+		if ( isExistingUserName ){
+			dataDetails = {
+				authorName: potentialUsername,
+				projectName: detailsStrings.slice(endUsernameIdx).join(' ')
+			}
+		}
+		endUsernameIdx -= 1;
+	}
+	return dataDetails;
+}

--- a/generators/generateCards.services.js
+++ b/generators/generateCards.services.js
@@ -1,0 +1,53 @@
+const util = require("node:util");
+const { exec } = require('node:child_process');
+const execPromise = util.promisify(exec);
+
+
+/**
+ * Checks URL requests response status code
+ * - is 404: username does not exist
+ * - else: username does exist
+ */
+async function isExistingGithubUsername ( possibleUsername ){
+	const githubUrl = `https://github.com/${possibleUsername}`;
+	const curlRequestForStatusCode = `curl --head -s "${githubUrl}" | awk 'NR==1 {print $2}'`;
+
+	try {
+		const { stdout } = await execPromise(curlRequestForStatusCode);
+		return Number(stdout) !== 404;
+	} catch( error ){
+		return false;
+	}
+}
+
+/**
+ * Handles directory names with multiple hyphens to get 
+ * the real distinction between the official author name and
+ * the project name
+ * @returns authorName, projectName 
+ */
+async function handleExtraHyphens(detailsStrings){
+	let endUsernameIdx = detailsStrings.length - 1;
+	let dataDetails;
+
+	// while it is within author name possible range
+	while (endUsernameIdx >= -1 && !dataDetails ){
+		let potentialUsername = detailsStrings
+			.slice(0, endUsernameIdx)
+			.join('-');
+		const isExistingUserName = await isExistingGithubUsername(potentialUsername);
+
+		if ( isExistingUserName ){
+			dataDetails = {
+				authorName: potentialUsername,
+				projectName: detailsStrings.slice(endUsernameIdx).join(' ')
+			}
+		}
+		endUsernameIdx -= 1;
+	}
+	return dataDetails;
+}
+
+module.exports = {
+	handleExtraHyphens
+}

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -1,0 +1,20 @@
+const formatProjectName = ( projectName ) => {
+ 	// Handles camel case project name
+	if( /[a-z][A-Z]/.test(projectName)){
+		projectName = projectName.replaceAll(/([A-Z])/g, ' $1');
+	}
+
+	// Handles hyphens in project name
+	if ( projectName.includes('-')){
+		projectName = projectName.replaceAll('-', ' ');
+	}
+
+	// Handles underscores in project name
+	if( projectName.includes('_') ){
+		projectName = projectName.replace('_', ' ');
+	}
+
+	return projectName.trim();
+}
+
+module.exports = { formatProjectName };


### PR DESCRIPTION
Maintenance - follow up on #2667
Once the repo is up to date ( all PRs adds their meta.json ) the file `__fixWithMetaData` can be deleted 

Purposely have all the Art directories changes with the `meta.json` file

Branch having the code to generate `meta.json` for all the folders in Art ( retro-compatibility with next project update )
so the github action only relies on `generators/generateCards` file to generate cards from existing `meta.json` 
- Art folders : current ones all have a `meta.json` file
- `generators/generateCards` will only rely on `meta.json` for author and title
- pull request template updated accordingly - specify to add the meta.json
- readme instruction updated accordingly - specify to add the meta.json

A student now need to add in their folder a `meta.json` file to indicated
```json
{
  "githubHandler": <github-user-name>,
  "artName": <animation-name>
}
```

Here is an example of what meta.json is generated and the card content output
<img width="583" alt="Screenshot 2024-10-09 at 16 53 41" src="https://github.com/user-attachments/assets/d44e0d30-8299-429b-b7b1-4930aa1ff238">
