### PR TITLE
[ core/update-post-merge-deps ] Updated github actions for post-merge…

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -24,11 +24,11 @@ jobs:
       group: post-merge
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - name: Install job dependencies


### PR DESCRIPTION
Updates the post-merge workflow to use Node.js 24-compatible versions of actions/checkout and actions/setup-node, addressing the GitHub Actions Node.js 20 deprecation warning.

- `actions/checkout@v4` → `@v7`
- `actions/setup-node@v4` → `@v7`
- `node-version: 20` → `24` 

Based on this repository/actions/summary annotation
<img width="983" height="177" alt="image" src="https://github.com/user-attachments/assets/14085ed1-d777-449c-aff4-90ecd7f46cf4" />
