### PR TITLE
Updated actions to v7 and node to 24

### DIFF
--- a/.github/workflows/pre-review.yml
+++ b/.github/workflows/pre-review.yml
@@ -1,7 +1,7 @@
 name: PR Pre-review
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ master ]
     types: [opened, synchronize, reopened, closed]
   pull_request_review:
@@ -17,14 +17,12 @@ env:
 
 jobs:
   pre-review:
-    if: github.event_name == 'pull_request_target' && github.event.action != 'closed'
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 50
           
       - name: Fetch master branch
@@ -45,10 +43,10 @@ jobs:
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         if: steps.check-skip.outputs.skip != 'true'
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
 


### PR DESCRIPTION
Maintenance - fixing pre-review versions for:
- `actions/checkout@v4` -> `@v7`
- `actions/setup-node@v4` -> `@v7`
- node-version: 24

Modify pull_request_target to pull_request for raised error in actions/summary 
Goal: avoid blocking ci/cd workflows